### PR TITLE
Reading the env variable from the ENV_DIR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,11 @@ CACHE_DIR=$2
 DEFAULT_SWIFT_VERSION="DEVELOPMENT-SNAPSHOT-2016-04-12-a"
 CLANG_VERSION=3.7.0
 
-if [ -z "$SWIFT_BUILD_CONFIGURATION" ]; then
+# Reading the environment variables, these are set as flat files under the ENV_DIR
+# ENV_DIR is passed as the third argument
+if [ -f "$3/SWIFT_BUILD_CONFIGURATION" ]; then
+  SWIFT_BUILD_CONFIGURATION=`cat "$3/SWIFT_BUILD_CONFIGURATION"`
+else
   SWIFT_BUILD_CONFIGURATION="release"
 fi
 


### PR DESCRIPTION
The environment variables are not passed as `env` to `bin/compile` they are flattened as files under the cache directory.
To an env variable, like `SWIFT_BUILD_CONFIGURATION`, we need to read the file with the same name located under `ENV_DIR/FILE_NAME`.
Furthermore, `ENV_DIR` is passed as the third positional argument to `bin/compile`

More info are from buildpacks api.
https://devcenter.heroku.com/articles/buildpack-api#bin-compile