### PR TITLE
Move to $BUILD_DIR before pre_compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -53,6 +53,7 @@ fi
 export PATH="$CACHE_DIR/clang-$CLANG_VERSION/clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-14.04/bin:$PATH"
 
 # Pre compile hook
+cd $BUILD_DIR
 source "$BIN_DIR/steps/hooks/pre_compile"
 
 cd $BUILD_DIR


### PR DESCRIPTION
When clang is not installed, it is failed to find pre_compile script.