### PR TITLE
Add -L flag to follow redirects when downloading clang

### DIFF
--- a/bin/steps/clang
+++ b/bin/steps/clang
@@ -2,7 +2,7 @@ if [[ ! -d "$CACHE_DIR/clang-$CLANG_VERSION" ]]; then
   cd $CACHE_DIR
   puts-step "Installing clang-$CLANG_VERSION"
   mkdir -p "clang-$CLANG_VERSION"
-  curl http://llvm.org/releases/$CLANG_VERSION/clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -s | xz -d -c | tar x -C clang-$CLANG_VERSION &> /dev/null
+  curl http://llvm.org/releases/$CLANG_VERSION/clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -s -L | xz -d -c | tar x -C clang-$CLANG_VERSION &> /dev/null
   cd $BUILD_DIR
 fi
 


### PR DESCRIPTION
This resolves #23.