### PR TITLE
Append to LD_LIBRARY_PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,6 +37,6 @@ source "$BIN_DIR/steps/swift-install"
 mkdir -p $BUILD_DIR/.profile.d
 
 set-env PATH '$HOME/.swift-bin:$PATH'
-set-env LD_LIBRARY_PATH '$HOME/.swift-lib'
+set-env LD_LIBRARY_PATH '$LD_LIBRARY_PATH:$HOME/.swift-lib'
 
 source "$BIN_DIR/steps/hooks/post_compile"


### PR DESCRIPTION
For Heroku apps with multiple buildpacks, this prevents wholesale replacement of the `LD_LIBRARY_PATH` environment variable.