### PR TITLE
Clone swiftenv manually if .git folder has been removed.

### DIFF
--- a/bin/steps/swiftenv
+++ b/bin/steps/swiftenv
@@ -1,10 +1,17 @@
 # Fetch swiftenv
-unset GIT_DIR
-git submodule update --init --recursive >/dev/null
 
-# Activate swiftenv
+unset GIT_DIR
 export SWIFTENV_ROOT="$CACHE_DIR/swiftenv"
 export PATH="$ROOT_DIR/swiftenv/bin:$PATH"
+
+if [ -d ".git" ]; then
+  git submodule update --init --recursive >/dev/null
+else
+  rm -rf $SWIFTENV_ROOT
+  git clone https://github.com/kylef/swiftenv.git $SWIFTENV_ROOT
+fi
+
+# Activate swiftenv
 eval "$(swiftenv init -)"
 
 if ! [ -f "$BUILD_DIR/.swift-version" ] && [ -z "$SWIFT_VERSION" ]; then


### PR DESCRIPTION
I was trying to use `heroku-buildpack-swift` as the buildpack for a server-side swift web app when deploying it to Pivotal Web Services (PWS), a large instance of Pivotal Cloud Foundry.  

I try to deploy my app using something like:

```shell
cf push my-special-app -b https://github.com/wileykestner/heroku-buildpack-swift.git
```

It appears that PWS removes the `.git` folder when it downloads the custom buildpack, so asking the buildpack to initialize it's submodules to bring in `swiftenv` doesn't work and the `bin/compile` script dies without successfully configuring the instance or deploying the web app.

I'm proposing a work-around in this PR that checks for the existence of the `.git` folder before attempting to initialize the git submodules.  If it can't find them, it goes and manually clones `swiftenv` and gets it onto the `PATH` in the same way initializing `swiftenv` as a submodule would.  Using this fork/PR I was able to successfully deploy my app on PWS.

I'm a total novice at buildpacks so please feel free to reject or request any amendments.  As it stands now, the diff is quite small and seems to allow a single buildpack to deploy swift 4.0 applications to both heroku and PWS (and possibly other cloud foundry instances, haven't tested).

CC'ing @drnic @briancroom because it appears that You Might Care™ based on Cursory Internet Research®